### PR TITLE
new: postgres: upgrade from 9.5 to 17 and migrate data

### DIFF
--- a/environment/postgres/Dockerfile
+++ b/environment/postgres/Dockerfile
@@ -1,4 +1,25 @@
-FROM postgres:9.5
+ARG POSTGRES_OLD="9.5"
+ARG POSTGRES_CUR="17"
+
+FROM postgres:${POSTGRES_CUR}
+ARG POSTGRES_OLD
+ARG POSTGRES_CUR
+
+# Install old PostgreSQL binaries (and basic utils - procps)
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends postgresql-${POSTGRES_OLD} && \
+    apt-get install -y procps && \
+    rm -rf /var/lib/apt/lists/*
+
+# use per-version data dir
+ENV PGDATA="/var/lib/postgresql/data/${POSTGRES_CUR}"
+
+# support older data with MD5 encryption (for authentication among our containers only)
+ENV POSTGRES_HOST_AUTH_METHOD=md5
+
+# create the dir for current version
+RUN install --verbose --directory --owner postgres --group postgres --mode 0700 "$PGDATA"
+
 COPY content /
 
 # Override entrypoint

--- a/environment/postgres/content/etc/startup.d/30-move-data.sh
+++ b/environment/postgres/content/etc/startup.d/30-move-data.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -eu
+
+# Move PostgreSQL data from /var/lib/postgresql/data
+# to versioned directory /var/lib/postgresql/data/$DATA_VERSION
+
+# Detect there is unmigrated data
+if [ -e /var/lib/postgresql/data/PG_VERSION ] ; then
+
+  DATA_VERSION=$( cat /var/lib/postgresql/data/PG_VERSION )
+  # Bail out if old data exist in both locations
+  if [ -e /var/lib/postgresql/data/$DATA_VERSION/PG_VERSION ] ; then
+    echo "Data exists both in /var/lib/postgresql/data and /var/lib/postgresql/data/$DATA_VERSION, aborting."
+    exit 1
+  fi
+
+  # Confirm we will be able to proceed with the upgrade
+  if [ ! -d "/usr/lib/postgresql/$DATA_VERSION" ] ; then
+    echo "Binaries for PostgreSQL $DATA_VERSION not found, upgrade not possible"
+    exit 1
+  fi
+
+  echo "Moving data from /var/lib/postgresql/data into /var/lib/postgresql/data/$DATA_VERSION"
+  install --verbose --directory --owner postgres --group postgres --mode 0700 "/var/lib/postgresql/data/$DATA_VERSION"
+  # Pattern to avoid moving the numeric version named directories (all PostgreSQL files or dirs start with a letter)
+  mv /var/lib/postgresql/data/[a-zA-Z]* /var/lib/postgresql/data/$DATA_VERSION
+
+  echo "Successfully moved data from /var/lib/postgresql/data into /var/lib/postgresql/data/$DATA_VERSION, recording $DATA_VERSION as current version"
+  echo $DATA_VERSION > /var/lib/postgresql/data/current
+else
+  echo "No unversioned data in /var/lib/postgresql/data, nothing to move"
+fi
+

--- a/environment/postgres/content/etc/startup.d/50-upgrade.sh
+++ b/environment/postgres/content/etc/startup.d/50-upgrade.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -eu
+
+# Migrate data from old PostgreSQL in /var/lib/postgresql/data/$DATA_VERSION
+# to new PostgreSQL in /var/lib/postgresql/data/$PG_MAJOR
+
+# Assume any old data is already moved to a versioned directory.
+if [ -e /var/lib/postgresql/data/PG_VERSION ] ; then
+    echo "Unversioned data found in /var/lib/postgresql/data/PG_VERSION, aborting."
+    exit 1
+fi
+
+# If the DB version file does not exist at this point,
+# initialise a new deployment.
+if [ ! -e /var/lib/postgresql/data/current ] ; then
+  echo "New install: initialising $PG_MAJOR database"
+  docker-ensure-initdb.sh
+  echo "New install: recording $PG_MAJOR as current version"
+  echo $PG_MAJOR > /var/lib/postgresql/data/current
+fi
+
+DATA_VERSION=$( cat /var/lib/postgresql/data/current )
+
+# Migrate data from old database to new
+if [ "${DATA_VERSION}" != "${PG_MAJOR}" ] ; then
+  # Confirm we will be able to proceed with the upgrade
+  if [ ! -d "/usr/lib/postgresql/$DATA_VERSION" ] ; then
+    echo "Binaries for PostgreSQL $DATA_VERSION not found, upgrade not possible"
+    exit 1
+  fi
+
+  # Make sure new database is initialised
+  echo "Upgrade: initialising empty $PG_MAJOR database"
+  docker-ensure-initdb.sh
+
+  # We will need a postgres-writeable current directory
+  WRKDIR=$( gosu postgres mktemp -d )
+  echo "Upgrading data from $DATA_VERSION to $PG_MAJOR"
+  ( cd $WRKDIR ; gosu postgres pg_upgrade --old-bindir="/usr/lib/postgresql/$DATA_VERSION/bin" --old-datadir=/var/lib/postgresql/data/$DATA_VERSION --new-datadir=/var/lib/postgresql/data/$PG_MAJOR )
+  rm -rf $WRKDIR
+  echo "Successfully upgraded, recording $PG_MAJOR as current version"
+  echo $PG_MAJOR > /var/lib/postgresql/data/current
+else
+  echo "Database already at version $PG_MAJOR"
+fi
+

--- a/environment/postgres/content/startup.sh
+++ b/environment/postgres/content/startup.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Propagate script errors
+set -eu
+
 # Exec all scripts from /etc/startup.d
 STARTUP_DIR=/etc/startup.d
 if [ -d "$STARTUP_DIR" ] ; then


### PR DESCRIPTION
Django 4.2 is not compatible with PostgreSQL 9.5, requires at least 12.

PostgreSQL version has been left untouched over the lifetime of the XeAP project,
but 9.5 is now seriously EOL.

While there are containers available for newer PostgreSQL version, they do not take care of data migration.

Solve this by:
(1) Switching to PostgreSQL 17 (current)
(2) Installing binaries for supported old PostgreSQL versions (9.5)
(3) Switching to versioned data directories - /var/lib/postgresql/data/$PG_VERSION instead of /var/lib/postgresql/data
(4) Recording current data version in  /var/lib/postgresql/data/current
(5) Adding a startup script 30-move-data.sh that moves data into the versioned directory if still unversioned.
(6) Adding a startup script 50-upgrade.sh that runs pg_upgrade to move data from old to new data dir.

The scripts do all reasonable sanity checking before any modifying action.

For simpler reasoning, the move to versioned format and actual upgrade are isolated tasks.

This also makes future upgrades easier to handle.

Scripts support either the above migration, or initialisation of a new empty environment.

The migration should be safe, as long as there is no "travel back in time" - once
the new container is run against a storage volume, the previous version should not be applied to it.